### PR TITLE
monitor: add permissions and resilient issue handling; default to /health

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,5 +1,10 @@
 name: CI / scheduled-monitor
 
+# Grant the workflow explicit permissions so it can create/update issues and labels
+permissions:
+  contents: read
+  issues: write
+
 on:
   schedule:
     - cron: '*/15 * * * *' # every 15 minutes — change as needed
@@ -8,7 +13,9 @@ on:
       url:
         description: 'Optional URL to check. If not provided, uses the DEPLOY_URL secret.'
         required: false
-        default: ''
+        # Default to the public /health endpoint for the deployed app. Override when manually
+        # dispatching if you want to check a different URL.
+        default: 'https://spring.anonyvote.onrender.com/health'
 
 jobs:
   monitor:
@@ -67,68 +74,76 @@ jobs:
             let url = 'unspecified';
             try { url = fs.readFileSync('logs/url.txt','utf8').trim(); } catch(e) { /* ignore */ }
 
-            const pendingLabel = 'monitor-pending';
-            const failLabel = 'monitor-failure';
+            // Wrap all GitHub API interactions in a try/catch so the workflow
+            // does not fail if the GITHUB_TOKEN lacks permission in this repo.
+            try {
+              const pendingLabel = 'monitor-pending';
+              const failLabel = 'monitor-failure';
 
-            // Ensure labels exist
-            async function ensureLabel(name, color, desc) {
-              try { await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name }); }
-              catch (e) { await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description: desc }); }
-            }
-            await ensureLabel(pendingLabel, 'f9d0c4', 'Pending monitor failures (awaiting threshold)');
-            await ensureLabel(failLabel, 'b60205', 'Open monitor failures');
-
-            // Find open issues with either label that reference this URL
-            const issues = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: `${pendingLabel},${failLabel}`, per_page: 100 });
-            const matched = (issues.data || []).filter(i => (i.body || '').includes(url));
-
-            if (rc === '0') {
-              // Success: close any matching pending or failure issues with recovery comment
-              for (const issue of matched) {
-                await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body: `Monitor recovered on run ${process.env.GITHUB_RUN_ID}. Closing issue.` });
-                await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, state: 'closed' });
-                console.log(`Closed issue #${issue.number} for URL ${url}`);
+              // Ensure labels exist (create if missing)
+              async function ensureLabel(name, color, desc) {
+                try { await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name }); }
+                catch (e) { try { await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description: desc }); } catch (err) { console.log(`Could not create label ${name}: ${err.message}`); } }
               }
-              if (matched.length === 0) console.log(`No open monitor issues found for URL ${url}; nothing to close.`);
+              await ensureLabel(pendingLabel, 'f9d0c4', 'Pending monitor failures (awaiting threshold)');
+              await ensureLabel(failLabel, 'b60205', 'Open monitor failures');
+
+              // Find open issues with either label that reference this URL
+              const issues = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: `${pendingLabel},${failLabel}`, per_page: 100 });
+              const matched = (issues.data || []).filter(i => (i.body || '').includes(url));
+
+              if (rc === '0') {
+                // Success: close any matching pending or failure issues with recovery comment
+                for (const issue of matched) {
+                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body: `Monitor recovered on run ${process.env.GITHUB_RUN_ID}. Closing issue.` });
+                  await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, state: 'closed' });
+                  console.log(`Closed issue #${issue.number} for URL ${url}`);
+                }
+                if (matched.length === 0) console.log(`No open monitor issues found for URL ${url}; nothing to close.`);
+                return;
+              }
+
+              // Failure handling with pending threshold
+              if (matched.length > 0) {
+                // Prefer pending issues if any
+                const pending = matched.find(i => (i.labels || []).some(l => l.name === pendingLabel));
+                const failed = matched.find(i => (i.labels || []).some(l => l.name === failLabel));
+
+                if (failed) {
+                  // Already escalated
+                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: failed.number, body: `Monitor still failing on run ${process.env.GITHUB_RUN_ID}. Exit code: ${rc}.` });
+                  console.log(`Existing failure issue #${failed.number} updated.`);
+                  return;
+                }
+
+                if (pending) {
+                  // Read failure_count from body
+                  const m = (pending.body || '').match(/failure_count:\s*(\d+)/i);
+                  let count = m ? parseInt(m[1], 10) : 0;
+                  count += 1;
+                  if (count >= threshold) {
+                    // Escalate: replace label with failLabel
+                    await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: `Threshold reached (${count}). Escalating to ${failLabel}.` });
+                    await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, labels: [failLabel] });
+                    console.log(`Escalated pending issue #${pending.number} to ${failLabel}.`);
+                  } else {
+                    // Update body with new count and add a comment
+                    const newBody = `failure_count: ${count}\n\nOriginal URL: ${url}\n\nLast run: ${process.env.GITHUB_RUN_ID}`;
+                    await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: newBody });
+                    await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: `Monitor failed again (run ${process.env.GITHUB_RUN_ID}). Count=${count}/${threshold}.` });
+                    console.log(`Updated pending issue #${pending.number} with count ${count}.`);
+                  }
+                  return;
+                }
+              }
+
+              // No existing issue: create a pending issue with failure_count = 1
+              const title = `Monitor (pending): health check failing for ${url}`;
+              const body = `failure_count: 1\n\nOriginal URL: ${url}\n\nFirst failing run: ${process.env.GITHUB_RUN_ID}\n\nArtifact: monitor-logs-${process.env.GITHUB_RUN_ID}`;
+              const issue = await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [pendingLabel] });
+              console.log(`Created pending issue #${issue.data.number} for URL ${url}`);
+            } catch (e) {
+              // Likely a permissions issue with GITHUB_TOKEN — log and continue without failing the job.
+              console.log(`Issue management skipped: ${e.message || e}`);
               return;
             }
-
-            // Failure handling with pending threshold
-            if (matched.length > 0) {
-              // Prefer pending issues if any
-              const pending = matched.find(i => (i.labels || []).some(l => l.name === pendingLabel));
-              const failed = matched.find(i => (i.labels || []).some(l => l.name === failLabel));
-
-              if (failed) {
-                // Already escalated
-                await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: failed.number, body: `Monitor still failing on run ${process.env.GITHUB_RUN_ID}. Exit code: ${rc}.` });
-                console.log(`Existing failure issue #${failed.number} updated.`);
-                return;
-              }
-
-              if (pending) {
-                // Read failure_count from body
-                const m = (pending.body || '').match(/failure_count:\s*(\d+)/i);
-                let count = m ? parseInt(m[1], 10) : 0;
-                count += 1;
-                if (count >= threshold) {
-                  // Escalate: replace label with failLabel
-                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: `Threshold reached (${count}). Escalating to ${failLabel}.` });
-                  await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, labels: [failLabel] });
-                  console.log(`Escalated pending issue #${pending.number} to ${failLabel}.`);
-                } else {
-                  // Update body with new count and add a comment
-                  const newBody = `failure_count: ${count}\n\nOriginal URL: ${url}\n\nLast run: ${process.env.GITHUB_RUN_ID}`;
-                  await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: newBody });
-                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pending.number, body: `Monitor failed again (run ${process.env.GITHUB_RUN_ID}). Count=${count}/${threshold}.` });
-                  console.log(`Updated pending issue #${pending.number} with count ${count}.`);
-                }
-                return;
-              }
-            }
-
-            // No existing issue: create a pending issue with failure_count = 1
-            const title = `Monitor (pending): health check failing for ${url}`;
-            const body = `failure_count: 1\n\nOriginal URL: ${url}\n\nFirst failing run: ${process.env.GITHUB_RUN_ID}\n\nArtifact: monitor-logs-${process.env.GITHUB_RUN_ID}`;
-            const issue = await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [pendingLabel] });
-            console.log(`Created pending issue #${issue.data.number} for URL ${url}`);

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ root pages. A small UI (poll creation + poll listing) has been merged into
 `src/main/resources/templates/index.html`. There are no longer competing static
 `index.html` files in the `resources/static/` folder.
 
+## Monitoring
+
+This repository includes a scheduled monitor workflow that checks the public
+`/health` endpoint of the deployed app and uploads debug artifacts when the
+check fails. If you see monitor failures, check the monitoring PR and issue
+for diagnostic logs:
+
+- Diagnostic PR with monitoring changes: https://github.com/Git-Leon/spring.anonyvote/pull/5
+- Active Issue tracking the current TLS/SNI problem: https://github.com/Git-Leon/spring.anonyvote/issues/9
+
+If you are responsible for the hosting/CDN configuration, please ensure the
+deployed hostname (for example, `spring.anonyvote.onrender.com`) is added as a
+custom domain on your hosting provider and that HTTPS is provisioned for it.
+The monitor collects `curl`/OpenSSL debug output to help diagnose TLS issues.
+
 ## JaCoCo coverage report (published)
 
 The JaCoCo HTML report has been published to GitHub Pages for this repository.

--- a/docs/RENDER_TLS_SUPPORT.md
+++ b/docs/RENDER_TLS_SUPPORT.md
@@ -1,0 +1,75 @@
+# Hosting / TLS Diagnostic: spring.anonyvote.onrender.com
+
+This file contains a concise, ready-to-send support message and repro steps you can use when contacting your hosting provider (Render / CDN / Cloudflare) to fix the TLS/SNI problem that prevents the monitor from reaching the app's `/health` endpoint.
+
+Summary of the issue
+--------------------
+- Symptom: TLS handshake fails (SSL alert 40 / `sslv3 alert handshake failure`) when clients present SNI `spring.anonyvote.onrender.com`.
+- Evidence: TCP connect succeeds, but the TLS handshake is aborted by the edge when SNI = `spring.anonyvote.onrender.com`. The handshake succeeds and a cert is returned when SNI = `onrender.com`.
+
+Key diagnostic commands (run from your environment or share with support)
+------------------------------------------------------------------------
+1) DNS and CNAME check
+
+```bash
+nslookup spring.anonyvote.onrender.com
+```
+
+2) TLS handshake repro (SNI = app subdomain)
+
+```bash
+openssl s_client -connect spring.anonyvote.onrender.com:443 -servername spring.anonyvote.onrender.com -showcerts
+```
+
+Expected: a certificate and successful handshake. Actual: handshake aborts with alert 40.
+
+3) TLS handshake repro (SNI = onrender.com)
+
+```bash
+openssl s_client -connect spring.anonyvote.onrender.com:443 -servername onrender.com -showcerts
+```
+
+Observed: handshake succeeds and the edge returns a certificate for `onrender.com`.
+
+4) curl verbose test (shows client-side OpenSSL error)
+
+```bash
+curl -v https://spring.anonyvote.onrender.com/health
+# or forcing the IP: curl -v --resolve spring.anonyvote.onrender.com:443:<IP> https://spring.anonyvote.onrender.com/health
+```
+
+What the provider needs to know (paste into support ticket)
+-----------------------------------------------------------
+Hello — I am seeing a TLS handshake failure for my app subdomain `spring.anonyvote.onrender.com` when clients present that hostname via SNI. The same edge IPs successfully negotiate TLS when SNI is `onrender.com` and return a certificate for `onrender.com`. This indicates the TLS termination layer is not serving a certificate for the app subdomain and is aborting the handshake for that SNI.
+
+Observed evidence (from my tests):
+- `openssl s_client -connect spring.anonyvote.onrender.com:443 -servername spring.anonyvote.onrender.com` → handshake fails (SSL alert 40).
+- `openssl s_client -connect spring.anonyvote.onrender.com:443 -servername onrender.com` → handshake succeeds and cert CN = onrender.com.
+- `curl -v https://spring.anonyvote.onrender.com/health` → `sslv3 alert handshake failure` in curl debug.
+
+Please check the following on the hosting/proxy side:
+1. Is `spring.anonyvote.onrender.com` added as a custom domain for the service? If not, please add it and enable HTTPS.
+2. If a CDN/proxy (Cloudflare or similar) is in front, verify that the hostname's CNAME/DNS is correctly configured and that the proxy is set to present a certificate for `spring.anonyvote.onrender.com` (or disable the proxy temporarily to test direct TLS).
+3. If automatic Let's Encrypt provisioning is used, check whether certificate provisioning failed or is pending for this hostname.
+4. If required, provision/attach a valid certificate for `spring.anonyvote.onrender.com` and ensure the TLS edge serves it for that SNI.
+
+How to verify the fix (after provider confirms changes)
+-----------------------------------------------------
+Run:
+
+```bash
+openssl s_client -connect spring.anonyvote.onrender.com:443 -servername spring.anonyvote.onrender.com -showcerts
+curl -v https://spring.anonyvote.onrender.com/health -I
+```
+
+Expected: TLS handshake succeeds, certificate subjectAltName includes `spring.anonyvote.onrender.com`, and `GET /health` returns HTTP 200.
+
+Notes for Cloudflare users
+-------------------------
+- If you're using Cloudflare, ensure the DNS entry for the hostname is a CNAME to the Render target and that SSL/TLS mode is set to `Full (strict)` if possible. Consider temporarily disabling the Cloudflare proxy (grey-cloud) to test direct TLS provisioning.
+
+Repository context
+------------------
+I added this diagnostic file to the repository branch `monitor/fix-issues-perms` and referenced it in PR #5; see `.github/workflows/monitor.yml` and `scripts/health_check.sh` for how the GitHub Actions monitor invokes `/health` and uploads debug artifacts.
+
+-- End of message

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -14,28 +14,36 @@ LOG_FILE="$OUT_DIR/health.log"
 
 echo "[$TIMESTAMP] Checking: $URL" | tee -a "$LOG_FILE"
 
+# Run curl and capture HTTP status, response body, and verbose/debug output to logs.
+# This makes TLS/handshake errors visible in the uploaded artifacts.
+TMP_BODY="$OUT_DIR/response_body.tmp"
+TMP_DEBUG="$OUT_DIR/curl_debug.txt"
+
 if [ -n "$API_TOKEN" ]; then
-  STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $API_TOKEN" "$URL" || echo "000")
+  # send verbose output to debug file and capture the body separately
+  STATUS=$(curl -s -S --max-time 10 -w "%{http_code}" -o "$TMP_BODY" -H "Authorization: Bearer $API_TOKEN" "$URL" 2>"$TMP_DEBUG" || echo "000")
 else
-  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+  STATUS=$(curl -s -S --max-time 10 -w "%{http_code}" -o "$TMP_BODY" "$URL" 2>"$TMP_DEBUG" || echo "000")
 fi
 
 echo "[$TIMESTAMP] HTTP status: $STATUS" | tee -a "$LOG_FILE"
 
 if [ "$STATUS" = "200" ]; then
   echo "[$TIMESTAMP] OK" | tee -a "$LOG_FILE"
+  # Save a small sample of the body and the debug output for good measure
+  head -c 65536 "$TMP_BODY" > "$OUT_DIR/last_response.html" || true
+  echo "[${TIMESTAMP}] Saved sample response to $OUT_DIR/last_response.html" | tee -a "$LOG_FILE"
+  echo "[${TIMESTAMP}] Saved curl debug to $TMP_DEBUG" | tee -a "$LOG_FILE"
+  rm -f "$TMP_BODY" || true
   exit 0
 else
   echo "[$TIMESTAMP] NOT OK - status $STATUS" | tee -a "$LOG_FILE"
-  # Optionally dump a small sample of the HTML for diagnosis
+  # Dump a small sample of the HTML and the verbose curl debug for diagnosis
   if [ -n "$(command -v curl)" ]; then
-    TMP_HTML="$OUT_DIR/last_response.html"
-    if [ -n "$API_TOKEN" ]; then
-      curl -s -H "Authorization: Bearer $API_TOKEN" "$URL" -o "$TMP_HTML" || true
-    else
-      curl -s "$URL" -o "$TMP_HTML" || true
-    fi
-    echo "[${TIMESTAMP}] Saved sample response to $TMP_HTML" | tee -a "$LOG_FILE"
+    head -c 65536 "$TMP_BODY" > "$OUT_DIR/last_response.html" || true
+    echo "[${TIMESTAMP}] Saved sample response to $OUT_DIR/last_response.html" | tee -a "$LOG_FILE"
+    echo "[${TIMESTAMP}] Saved curl debug to $TMP_DEBUG" | tee -a "$LOG_FILE"
   fi
+  rm -f "$TMP_BODY" || true
   exit 2
 fi


### PR DESCRIPTION
This PR adds workflow-level permissions for issues (so the monitor can create/update issues/labels), makes issue handling resilient to missing token permissions, and sets the default workflow_dispatch URL to the public /health endpoint.\n\nI also ran the workflow on this branch and confirmed the run created a pending monitor issue (issue #4) because the health check returned status 000 (TLS handshake failure). See run 23622757181 for details and attached logs.\n\nPlease review; I will only merge after explicit approval.